### PR TITLE
Loosen version range of concat-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "tape test.js"
   },
   "dependencies": {
-    "once": "~1.3.0",
-    "concat-stream": "~1.2.0"
+    "once": "^1.3.0",
+    "concat-stream": "^1.2.0"
   },
   "devDependencies": {
     "tape": "~2.1.0",


### PR DESCRIPTION
I think we can trust @maxogden and @isaacs to follow semver, and this prevents `collect-stream` from installing a redundant (and somewhat old) version of `concat-stream` in certain cases.
