### PR TITLE
support passing options to concat-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ collect(objectStream, (err, data) => {
 });
 ```
 
+Give it options and it will pass them to [concat-stream](https://github.com/maxogden/concat-stream/).
+
+```js
+import collect from 'collect-stream';
+
+opts = {encoding: "object"}
+
+collect(opts, unknownStream, (err, data) => {
+  console.log(data) // forced to be an array of objects
+});
+```
+
 ## Installation
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 import { default as concat } from 'concat-stream';
 import { default as once } from 'once';
 
-export default function collect(stream, fn) {
+export default function collect(opts, stream, fn) {
+  if (!fn) {
+    fn = stream;
+    stream = opts;
+    opts = null;
+  }
   fn = once(fn);
   stream.on('error', fn);
-  stream.pipe(concat(data => {
+  stream.pipe(concat(opts, data => {
     fn(null, data);
   }));
 };

--- a/test.js
+++ b/test.js
@@ -57,6 +57,26 @@ test('object', t => {
   });
 });
 
+test('array without flattening', t => {
+  t.plan(2);
+
+  var stream = through();
+
+  process.nextTick(() => {
+    stream.queue([{ foo: true }]);
+    stream.queue([{ bar: true }]);
+    stream.queue(null);
+  });
+
+  collect(stream, (err, data) => {
+    t.error(err);
+    t.deepEqual(data, [
+      [{ foo: true }],
+      [{ bar: true }]
+    ]);
+  });
+});
+
 test('error', t => {
   t.plan(1);
   

--- a/test.js
+++ b/test.js
@@ -60,7 +60,8 @@ test('object', t => {
 test('array without flattening', t => {
   t.plan(2);
 
-  var stream = through();
+  var stream = through(),
+      opts = {encoding: "object"};
 
   process.nextTick(() => {
     stream.queue([{ foo: true }]);
@@ -68,7 +69,7 @@ test('array without flattening', t => {
     stream.queue(null);
   });
 
-  collect(stream, (err, data) => {
+  collect(opts, stream, (err, data) => {
     t.error(err);
     t.deepEqual(data, [
       [{ foo: true }],


### PR DESCRIPTION
Hello,

I'm using collect-stream to collect a group of arrays.  **concat-stream** infers this as an array-formatted stream instead of object-formatted stream and flattens the collection.  Passing options to **concat-stream** solves the issue, and is backwards-compatible.

I am first pushing the test case to show how it breaks, then the fix in a second commit.

Thanks for your work!